### PR TITLE
マークダウン対応

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,9 @@ jobs:
       - name: Install md2review gem
         run: gem install md2review
       - name: Convert MD to Re:VIEW
-        run: sh convert-markdown.sh
-      - name: show review files
-        run: ls src/*.re
-      - run: cat src/ponyoxa1.re
+        run: |
+          sh convert-markdown.sh
+          ls src/*.re
       - name: Create PDF
         run: |
           cd src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,7 @@ jobs:
       - name: Install md2review gem
         run: gem install md2review
       - name: Convert MD to Re:VIEW
-        run: |
-          cd src
-          for file in *.md; do
-            md2review "$file" > "${file%.md}.re"
-          done
+        run: sh convert-markdown.sh
       - name: Show review files
         run: ls src/*.re
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     container: docker://vvakame/review:3.1
     steps:
+      - name: Install md2review gem
+        run: gem install md2review
+      - name: Convert MD to Re:VIEW
+        run: |
+          cd src
+          for file in *.md; do
+            md2review "$file" > "${file%.md}.re"
+          done
+      - name: Show review files
+        run: ls src/*.re
       - uses: actions/checkout@v3
       - name: Create PDF
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,9 @@ jobs:
         run: gem install md2review
       - name: Convert MD to Re:VIEW
         run: sh convert-markdown.sh
-      - name: Show review files
+      - name: show review files
         run: ls src/*.re
+      - run: cat src/ponyoxa1.re
       - name: Create PDF
         run: |
           cd src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     container: docker://vvakame/review:3.1
     steps:
+      - uses: actions/checkout@v3
       - name: Install md2review gem
         run: gem install md2review
       - name: Convert MD to Re:VIEW
         run: sh convert-markdown.sh
       - name: Show review files
         run: ls src/*.re
-      - uses: actions/checkout@v3
       - name: Create PDF
         run: |
           cd src

--- a/convert-markdown.sh
+++ b/convert-markdown.sh
@@ -1,5 +1,5 @@
 for file in `ls ./src/*.md`
 do
   echo "Converting $file to ${file%.md}.re"
-  cat "$file" > "${file%.md}.re"
+  md2review "$file" > "${file%.md}.re"
 done

--- a/convert-markdown.sh
+++ b/convert-markdown.sh
@@ -1,0 +1,5 @@
+for file in `ls ./src/*.md`
+do
+  echo "Converting $file to ${file%.md}.re"
+  cat "$file" > "${file%.md}.re"
+done

--- a/src/catalog.yml
+++ b/src/catalog.yml
@@ -12,7 +12,9 @@ CHAPS:
       - Rhodium1.re
       - Rhodium2.re
       - Rhodium3.re
-      - ponyoxa1.md
+      # マークダウンファイルはGitHub Actionsで*.reに変換されます。
+      # catalogには変換後のreファイルを記述してください。
+      - ponyoxa1.re
 
   # 2部 友人
   #- chap-friend-00-index.re:


### PR DESCRIPTION
GitHub Actionsで本をビルドする際、srcに存在するmdファイルをreに変換する処理を追加しました。
reviewへの変換対応が必要なくなり、著者がマークダウンを用意するだけで本になります。

ローカルで動作させる場合は個別で、以下のコマンドを実行してからRe:VIEWを実行してください。

```sh
sh convert-markdown.sh
```
