### PR TITLE
update: SLACK_WEBHOOK_URL が空の場合は stats 処理をスキップ

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -6,8 +6,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-env:
+    runs-on: ubuntu-latest
+
+    outputs:
+      slack_webhook_set: ${{ steps.check-slack-webhook.outputs.slack_webhook_set }}
+
+    steps:
+      - name: Check SLACK_WEBHOOK_URL
+        id: check-slack-webhook
+        run: |
+          if [ -z "${{ secrets.SLACK_WEBHOOK_URL }}" ]; then
+            echo "SLACK_WEBHOOK_URL is not set. Skipping the job."
+            echo "slack_webhook_set=false" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "slack_webhook_set=true" >> $GITHUB_OUTPUT
+          fi
+
   check-and-notify:
     runs-on: ubuntu-latest
+    needs: check-env
+    if: needs.check-env.outputs.slack_webhook_set == 'true'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
- skip(SLACK_WEBHOOK_URLがセットされていないケース)
    - https://github.com/yumechi/learning/actions/runs/12166652305
- success(SLACK_WEBHOOK_URLがセットされているケース） 
    - https://github.com/yumechi/learning/actions/runs/12166580741

job を分けずに対応したかったのですが、SLACK_WEBHOOK_URL がセットされていない場合に下記の問題が起こり、確実に実行させるため job を分けました。

- secrets.SLACK_WEBHOOK_URL が各 job の steps の前に取得できない
    - https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability
    - このあたりの制限によるものと思われます
- step の先頭で失敗させた場合に、ステータスを failed にせずに step の実行を終わらせられなかった
    - https://docs.github.com/ja/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
    - continue-on-error などを使えないか検討していましたが、うまく適用できませんでした

さらに良い方法はあるのかもしれませんが job を分けることで前の job で outputs に書き込んだ値を読み込むことで実行の継続、中断を確実に判定すること、failed の通知が fork 先に及ばないことを念頭に対応しました。